### PR TITLE
Support for changeover groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+/bin
+/pyvenv.cfg
+/test.py


### PR DESCRIPTION
Recurse through entire Kumo structure, so that units that are nested inside changeover groups are visible.