### PR TITLE
Interactive usage improvements to KumoCloudAccount

### DIFF
--- a/pykumo/pykumo.py
+++ b/pykumo/pykumo.py
@@ -1,6 +1,7 @@
 """ Module to interact with Mitsubishi KumoCloud devices via their local API.
 """
 
+import re
 import hashlib
 import base64
 import time
@@ -561,6 +562,16 @@ class KumoCloudAccount:
         kumos = {}
         for iu in list(self.get_indoor_units()):
             name = self.get_name(iu)
+            if name in kumos:
+                # I'm not sure if it's possible to have the same name repeated,
+                # but just in case...
+                m = re.match(r'(.*) \(([0-9]*)\)', name)
+                if m:
+                    name = m.group(1) + ' ({})'.format(int(m.group(2)) + 1)
+                else:
+                    kumos[name + ' (1)'] = kumos.pop(name)
+                    name = name + ' (2)'
+                # results in a name like "A/C unit (2)"
             kumos[name] = PyKumo(name, self.get_address(iu),
                                  self.get_credentials(iu), timeouts)
         return kumos

--- a/pykumo/pykumo.py
+++ b/pykumo/pykumo.py
@@ -5,6 +5,7 @@ import hashlib
 import base64
 import time
 import logging
+from getpass import getpass
 import requests
 from urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
@@ -402,9 +403,14 @@ class PyKumo:
 class KumoCloudAccount:
     """ API to talk to KumoCloud servers
     """
-    def __init__(self, username, password, kumo_dict=None):
+    def __init__(self, username=None, password=None, kumo_dict=None):
         """ Constructor from URL
         """
+        if username is None:
+            username = input('Kumo Cloud username: ')
+        if password is None:
+            password = getpass()
+
         if kumo_dict:
             self._url = None
             self._kumo_dict = kumo_dict

--- a/pykumo/pykumo.py
+++ b/pykumo/pykumo.py
@@ -555,7 +555,7 @@ class KumoCloudAccount:
 
         return None
 
-    def make_pykumos(self, timeouts=None):
+    def make_pykumos(self, timeouts=None, init_update_status=True):
         """ Return a dict mapping names of all indoor units to newly-created
         `PyKumo` objects
         """
@@ -574,4 +574,9 @@ class KumoCloudAccount:
                 # results in a name like "A/C unit (2)"
             kumos[name] = PyKumo(name, self.get_address(iu),
                                  self.get_credentials(iu), timeouts)
+
+        if init_update_status:
+            for pk in kumos.values():
+                pk.update_status()
+
         return kumos

--- a/pykumo/pykumo.py
+++ b/pykumo/pykumo.py
@@ -547,3 +547,14 @@ class KumoCloudAccount:
             pass
 
         return None
+
+    def make_pykumos(self, timeouts=None):
+        """ Return a dict mapping names of all indoor units to newly-created
+        `PyKumo` objects
+        """
+        kumos = {}
+        for iu in list(self.get_indoor_units()):
+            name = self.get_name(iu)
+            kumos[name] = PyKumo(name, self.get_address(iu),
+                                 self.get_credentials(iu), timeouts)
+        return kumos


### PR DESCRIPTION
This PR adds a few conveniences I found helpful when trying to work with `KumoCloudAccount`.  Specifically:

1. If the user doesn't give a name and password it prompts for one using the `input` and `getpass` mechanisms
2. Adds a `make_pykumos` method that creates `PyKumo` objects for everything in the kumo cloud account, skipping over some mildly awkward creation steps.