### PR TITLE
Fix KumoCloudAccount unit parsing to consistently handle missing fields

### DIFF
--- a/pykumo/py_kumo_cloud_account.py
+++ b/pykumo/py_kumo_cloud_account.py
@@ -60,14 +60,10 @@ class KumoCloudAccount:
         """ Parse needed fields from raw json and return dict representing
             a unit
         """
-        unit = {}
         fields = {'serial', 'label', 'address', 'password', 'cryptoSerial', 'mac', 'unitType'}
-        try:
-            for field in fields:
-                unit[field] = raw_unit[field]
-        except KeyError:
-            pass
-        return unit
+        # Not all fields are always present; e.g. 'address'
+        common_fields = fields & raw_unit.keys()
+        return {field: raw_unit[field] for field in common_fields}
 
     def _fetch_if_needed(self):
         """ Fetch configuration from server.


### PR DESCRIPTION
Previously, the try block in _parse_unit(raw_unit) was outside of the for loop. That meant that as soon as a missing key was encountered, the function stopped iterating through subsequent keys, leading to a partial unit dict, even if more desired fields were present in the original raw_unit.

Additionally, iteration over the 'fields' set is non-deterministic because [Python set iteration is based on a random hash seed](https://stackoverflow.com/questions/3848091/set-iteration-order-varies-from-run-to-run).

These two factors combined could lead to unit parsing that sometimes worked and sometimes didn't. (e.g. if 'address' was missing and iterated through first, a completely empty unit dict would be returned).

May fix: https://github.com/dlarrick/hass-kumo/issues/109