### PR TITLE
Add V3 API support for credential retrieval with local network discovery

### DIFF
--- a/pykumo/__init__.py
+++ b/pykumo/__init__.py
@@ -1,7 +1,7 @@
 """ Module to interact with Mitsubishi KumoCloud devices via their local API.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.11'
 name = "pykumo"
 
 from .py_kumo_cloud_account import KumoCloudAccount

--- a/pykumo/__init__.py
+++ b/pykumo/__init__.py
@@ -1,10 +1,11 @@
 """ Module to interact with Mitsubishi KumoCloud devices via their local API.
 """
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'
 name = "pykumo"
 
 from .py_kumo_cloud_account import KumoCloudAccount
+from .py_kumo_cloud_account_v3 import KumoCloudV3
 from .py_kumo import PyKumo
 from .py_kumo_base import PyKumoBase
 from .py_kumo_station import PyKumoStation

--- a/pykumo/__init__.py
+++ b/pykumo/__init__.py
@@ -6,6 +6,7 @@ name = "pykumo"
 
 from .py_kumo_cloud_account import KumoCloudAccount
 from .py_kumo_cloud_account_v3 import KumoCloudV3
+from .py_kumo_discovery import probe_candidate_ips
 from .py_kumo import PyKumo
 from .py_kumo_base import PyKumoBase
 from .py_kumo_station import PyKumoStation

--- a/pykumo/py_kumo_cloud_account.py
+++ b/pykumo/py_kumo_cloud_account.py
@@ -9,6 +9,7 @@ from requests.exceptions import Timeout
 from getpass import getpass
 from .py_kumo import PyKumo
 from .py_kumo_station import PyKumoStation
+from .py_kumo_cloud_account_v3 import KumoCloudV3
 from .const import KUMO_CONNECT_TIMEOUT_SECONDS, KUMO_RESPONSE_TIMEOUT_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,20 +29,17 @@ class KumoCloudAccount:
     def __init__(self, username, password, kumo_dict=None):
         """ Constructor from URL
         """
+        self._username = username
+        self._password = password
+        self._units = {}
         if kumo_dict:
             self._url = None
             self._kumo_dict = kumo_dict
             self._need_fetch = False
-            self._username = None
-            self._password = None
-            self._units = {}
         else:
             self._url = "https://geo-c.kumocloud.com/login"
             self._kumo_dict = None
             self._need_fetch = True
-            self._username = username
-            self._password = password
-            self._units = {}
 
     @staticmethod
     def Factory(username=None, password=None):
@@ -111,11 +109,153 @@ class KumoCloudAccount:
         except KeyError:
             pass
 
+        # After V2 fetch, supplement missing credentials from V3 API
+        if self._username and self._password:
+            self._supplement_with_v3()
+
+    def _supplement_with_v3(self):
+        """Use the V3 API to fill in missing credentials (password, cryptoSerial).
+
+        After the Kumo Cloud migration, the V2 API may return stale or missing
+        passwords. The V3 API provides current data via REST and WebSocket.
+        """
+        missing = [s for s, u in self._units.items()
+                   if not u.get('password') or not u.get('cryptoSerial')]
+        if not missing:
+            _LOGGER.debug("All V2 credentials complete; skipping V3 supplement")
+            return
+
+        _LOGGER.info("V2 data incomplete for %d units, trying V3 API...", len(missing))
+
+        try:
+            v3 = KumoCloudV3(self._username, self._password)
+            v3_devices = v3.get_all_device_credentials()
+        except Exception as ex:
+            _LOGGER.warning("V3 credential retrieval failed: %s", ex)
+            return
+
+        if not v3_devices:
+            return
+
+        # Merge V3 data into units and raw dict
+        updated = 0
+        for serial, unit in self._units.items():
+            v3_dev = v3_devices.get(serial)
+            if not v3_dev:
+                continue
+            for field in ('password', 'cryptoSerial'):
+                if not unit.get(field) and v3_dev.get(field):
+                    unit[field] = v3_dev[field]
+                    updated += 1
+
+        if updated > 0 and self._kumo_dict:
+            self._update_raw_dict_credentials(v3_devices)
+
+        _LOGGER.info("V3 supplement: updated %d fields", updated)
+
+    def _update_raw_dict_credentials(self, v3_devices):
+        """Update raw kumo_dict with V3-sourced credentials for cache writes."""
+        try:
+            for child in self._kumo_dict[2]['children']:
+                for serial, raw_unit in child['zoneTable'].items():
+                    self._merge_v3_fields(raw_unit, v3_devices.get(serial))
+                for grandchild in child.get('children', []):
+                    for serial, raw_unit in grandchild['zoneTable'].items():
+                        self._merge_v3_fields(raw_unit, v3_devices.get(serial))
+        except (KeyError, IndexError):
+            pass
+
+    @staticmethod
+    def _merge_v3_fields(raw_unit, v3_dev):
+        """Merge password/cryptoSerial from V3 into a raw unit dict."""
+        if not v3_dev:
+            return
+        for field in ('password', 'cryptoSerial'):
+            if v3_dev.get(field) and not raw_unit.get(field):
+                raw_unit[field] = v3_dev[field]
+
     def try_setup(self):
         """Try to set up and return success/failure"""
         self._fetch_if_needed()
 
         return len(self._units.keys()) > 0
+
+    def try_setup_v3_only(self):
+        """Set up using only the V3 API (skip V2 entirely).
+
+        Useful when V2 API is broken for an account. Builds a minimal
+        V2-compatible kumo_dict from V3 data, preserving any device
+        addresses from a previously cached kumo_dict.
+        """
+        if not self._username or not self._password:
+            _LOGGER.warning("Cannot use V3-only setup without credentials")
+            return False
+
+        # Preserve cached addresses before overwriting _kumo_dict
+        cached_addresses = self._extract_cached_addresses()
+
+        try:
+            v3 = KumoCloudV3(self._username, self._password)
+            v3_devices = v3.get_all_device_credentials()
+        except Exception as ex:
+            _LOGGER.warning("V3-only setup failed: %s", ex)
+            return False
+
+        if not v3_devices:
+            return False
+
+        # Build V2-compatible kumo_dict from V3 data
+        zone_table = {}
+        for serial, dev in v3_devices.items():
+            entry = {
+                "serial": serial,
+                "label": dev.get("label", ""),
+                "password": dev.get("password", ""),
+                "cryptoSerial": dev.get("cryptoSerial", ""),
+                "mac": dev.get("mac", ""),
+                "unitType": dev.get("unitType", "ductless"),
+            }
+            if serial in cached_addresses:
+                entry["address"] = cached_addresses[serial]
+            zone_table[serial] = entry
+
+        self._kumo_dict = [
+            {},  # account info placeholder
+            {},  # preferences placeholder
+            {"children": [{"zoneTable": zone_table}]},
+        ]
+        self._need_fetch = False
+
+        self._units = {}
+        for serial, unit_data in zone_table.items():
+            self._units[serial] = self._parse_unit(unit_data)
+
+        _LOGGER.info("V3-only setup: found %d devices", len(self._units))
+        return len(self._units) > 0
+
+    def _extract_cached_addresses(self) -> dict:
+        """Extract device serial -> address mapping from current kumo_dict."""
+        addresses = {}
+        if not self._kumo_dict:
+            return addresses
+        try:
+            for child in self._kumo_dict[2]['children']:
+                for raw_unit in child['zoneTable'].values():
+                    serial = raw_unit.get('serial', '')
+                    address = raw_unit.get('address', '')
+                    if serial and address:
+                        addresses[serial] = address
+                for grandchild in child.get('children', []):
+                    for raw_unit in grandchild['zoneTable'].values():
+                        serial = raw_unit.get('serial', '')
+                        address = raw_unit.get('address', '')
+                        if serial and address:
+                            addresses[serial] = address
+        except (KeyError, IndexError, TypeError):
+            pass
+        if addresses:
+            _LOGGER.info("Preserved %d cached addresses", len(addresses))
+        return addresses
 
     def get_raw_json(self):
         """Return raw dict retrieved from KumoCloud"""

--- a/pykumo/py_kumo_cloud_account_v3.py
+++ b/pykumo/py_kumo_cloud_account_v3.py
@@ -1,0 +1,384 @@
+"""Kumo Cloud V3 API client for retrieving device credentials.
+
+The Mitsubishi Comfort app (successor to Kumo Cloud) uses a V3 REST + WebSocket
+API at app-prod.kumocloud.com. This module retrieves the credentials needed for
+local control of indoor units:
+  - password (from WebSocket adapter_update events)
+  - cryptoSerial (from /v3/devices/{serial}/status REST endpoint)
+
+These are merged into existing pykumo data structures so the local API code
+(PyKumoBase._token / ._request) works without changes.
+"""
+
+import base64
+import json
+import logging
+import time
+import threading
+from typing import Optional
+
+import requests
+from requests.exceptions import Timeout
+
+_LOGGER = logging.getLogger(__name__)
+
+V3_BASE_URL = "https://app-prod.kumocloud.com"
+SOCKET_URL = "https://socket-prod.kumocloud.com"
+V3_APP_VERSION = "3.2.4"
+V3_CLOUD_TIMEOUT = (10, 30)  # (connect, read)
+
+V3_BASE_HEADERS = {
+    "Accept": "application/json",
+    "Accept-Encoding": "gzip, deflate, br",
+    "x-app-version": V3_APP_VERSION,
+    "Content-Type": "application/json",
+}
+
+
+class KumoCloudV3:
+    """Client for the Kumo Cloud V3 API used by the Comfort app."""
+
+    def __init__(self, username: str, password: str):
+        self._username = username
+        self._password = password
+        self._access_token: Optional[str] = None
+        self._refresh_token: Optional[str] = None
+        self._cancel_event = threading.Event()
+
+    # ── Authentication ──────────────────────────────────────
+
+    def login(self) -> bool:
+        """Authenticate and obtain JWT tokens."""
+        body = {
+            "username": self._username,
+            "password": self._password,
+            "appVersion": V3_APP_VERSION,
+        }
+        try:
+            resp = requests.post(
+                f"{V3_BASE_URL}/v3/login",
+                headers=V3_BASE_HEADERS, json=body,
+                timeout=V3_CLOUD_TIMEOUT,
+            )
+        except Exception as ex:
+            _LOGGER.warning("V3 login error: %s", ex)
+            return False
+
+        if not resp.ok:
+            _LOGGER.warning("V3 login failed: %s %s", resp.status_code, resp.text[:200])
+            return False
+
+        token_data = resp.json().get("token", {})
+        self._access_token = token_data.get("access")
+        self._refresh_token = token_data.get("refresh")
+
+        if not self._access_token:
+            _LOGGER.warning("V3 login response missing access token")
+            return False
+
+        _LOGGER.info("V3 login successful")
+        return True
+
+    def refresh(self) -> bool:
+        """Refresh the access token."""
+        if not self._refresh_token:
+            return False
+
+        headers = {**V3_BASE_HEADERS, "Authorization": f"Bearer {self._refresh_token}"}
+        try:
+            resp = requests.post(
+                f"{V3_BASE_URL}/v3/refresh",
+                headers=headers,
+                json={"refresh": self._refresh_token},
+                timeout=V3_CLOUD_TIMEOUT,
+            )
+        except Exception as ex:
+            _LOGGER.warning("V3 token refresh error: %s", ex)
+            return False
+
+        if not resp.ok:
+            return False
+
+        data = resp.json()
+        self._access_token = data.get("access")
+        self._refresh_token = data.get("refresh")
+        return bool(self._access_token)
+
+    def _auth_headers(self) -> dict:
+        return {**V3_BASE_HEADERS, "Authorization": f"Bearer {self._access_token}"}
+
+    def _get_user_id_from_token(self) -> Optional[str]:
+        """Extract user ID from the JWT payload (needed for account subscription)."""
+        if not self._access_token:
+            return None
+        try:
+            payload_b64 = self._access_token.split(".")[1]
+            # Add base64 padding
+            payload_b64 += "=" * (4 - len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+            user_id = payload.get("id")
+            return str(user_id) if user_id is not None else None
+        except Exception as ex:
+            _LOGGER.warning("Failed to extract user ID from JWT: %s", ex)
+            return None
+
+    # ── REST API ────────────────────────────────────────────
+
+    def _get(self, path: str):
+        """Authenticated GET with automatic token refresh on 401."""
+        url = f"{V3_BASE_URL}{path}"
+        try:
+            resp = requests.get(url, headers=self._auth_headers(), timeout=V3_CLOUD_TIMEOUT)
+        except Exception as ex:
+            _LOGGER.warning("V3 GET %s error: %s", path, ex)
+            return None
+
+        if resp.status_code == 401 and self.refresh():
+            try:
+                resp = requests.get(url, headers=self._auth_headers(), timeout=V3_CLOUD_TIMEOUT)
+            except Exception as ex:
+                _LOGGER.warning("V3 GET %s error after refresh: %s", path, ex)
+                return None
+
+        if not resp.ok:
+            _LOGGER.warning("V3 GET %s: HTTP %s", path, resp.status_code)
+            return None
+
+        try:
+            return resp.json()
+        except Exception:
+            return None
+
+    def get_sites(self) -> list:
+        result = self._get("/v3/sites/")
+        return result if isinstance(result, list) else []
+
+    def get_zones(self, site_id: str) -> list:
+        result = self._get(f"/v3/sites/{site_id}/zones")
+        return result if isinstance(result, list) else []
+
+    def get_device_status(self, serial: str) -> Optional[dict]:
+        return self._get(f"/v3/devices/{serial}/status")
+
+    def cancel(self):
+        """Signal the Socket.IO poll loop to stop (for clean HA shutdown)."""
+        self._cancel_event.set()
+
+    # ── Socket.IO Password Retrieval ────────────────────────
+
+    def get_passwords_via_websocket(self, device_serials: list, timeout_secs: int = 30) -> dict:
+        """Connect to Socket.IO and collect adapter_update events with passwords."""
+        if not self._access_token:
+            return {}
+
+        self._cancel_event.clear()
+        try:
+            return self._socketio_session(set(device_serials), timeout_secs)
+        except Exception as ex:
+            _LOGGER.warning("WebSocket password retrieval error: %s", ex)
+            return {}
+
+    def _socketio_session(self, serials_needed: set, timeout_secs: int,
+                          _retried: bool = False) -> dict:
+        """Run a complete Socket.IO session: handshake, subscribe, poll.
+
+        If the namespace connect is rejected (expired token), refreshes
+        the token and retries once.
+        """
+        passwords = {}
+        session = requests.Session()
+        base_params = {"EIO": "4", "transport": "polling"}
+        headers = {"Authorization": f"Bearer {self._access_token}", "Accept": "*/*"}
+
+        # 1. Handshake
+        try:
+            resp = session.get(
+                f"{SOCKET_URL}/socket.io/", params=base_params,
+                headers=headers, timeout=15,
+            )
+        except Exception as ex:
+            _LOGGER.warning("Socket.IO handshake failed: %s", ex)
+            return passwords
+
+        if not resp.ok or not resp.text.startswith("0"):
+            _LOGGER.warning("Socket.IO handshake unexpected: %s", resp.text[:200])
+            return passwords
+
+        try:
+            sid = json.loads(resp.text[1:]).get("sid")
+        except json.JSONDecodeError:
+            _LOGGER.warning("Socket.IO handshake parse error")
+            return passwords
+
+        _LOGGER.debug("Socket.IO connected, sid=%s", sid)
+        poll_params = {**base_params, "sid": sid}
+        post_headers = {**headers, "Content-Type": "text/plain;charset=UTF-8"}
+
+        def _post(data):
+            session.post(f"{SOCKET_URL}/socket.io/", params=poll_params,
+                         headers=post_headers, data=data, timeout=10)
+
+        def _poll(timeout=10):
+            return session.get(f"{SOCKET_URL}/socket.io/", params=poll_params,
+                               headers=headers, timeout=timeout)
+
+        # 2. Namespace connect
+        _post("40")
+        resp = _poll()
+
+        # Check for rejection (token expired)
+        if resp.ok and resp.text.startswith("44") and not _retried:
+            _LOGGER.info("Socket.IO namespace rejected, refreshing token...")
+            if self.refresh():
+                return self._socketio_session(serials_needed, timeout_secs, _retried=True)
+            _LOGGER.warning("Token refresh failed")
+            return passwords
+
+        # 3. Account-level subscribe (required for adapter_update events)
+        user_id = self._get_user_id_from_token()
+        if user_id:
+            _post(f'42["subscribe","","{user_id}"]')
+            resp = _poll()
+            if resp.ok:
+                self._extract_passwords(resp.text, passwords, serials_needed)
+        else:
+            _LOGGER.warning("Could not extract user ID — adapter_update events may not arrive")
+
+        # 4. Subscribe to each device
+        _post("\x1e".join(f'42["subscribe","{s}"]' for s in serials_needed))
+        resp = _poll()
+        if resp.ok:
+            self._extract_passwords(resp.text, passwords, serials_needed)
+
+        # 5. Force adapter_update events (contains passwords)
+        _post("\x1e".join(
+            f'42["force_adapter_request","{s}","adapterStatus"]' for s in serials_needed
+        ))
+
+        # 6. Send device_status_v2 to trigger updates
+        status_msgs = ['42["device_status_v2",""]']
+        status_msgs.extend(f'42["device_status_v2","{s}"]' for s in serials_needed)
+        _post("\x1e".join(status_msgs))
+
+        # 7. Poll for adapter_update events
+        deadline = time.monotonic() + timeout_secs
+        poll_count = 0
+        while time.monotonic() < deadline and serials_needed - set(passwords.keys()):
+            if self._cancel_event.is_set():
+                break
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            poll_count += 1
+            try:
+                resp = _poll(timeout=min(25, remaining + 1))
+            except Timeout:
+                continue
+            except Exception:
+                break
+
+            if not resp.ok:
+                break
+
+            self._extract_passwords(resp.text, passwords, serials_needed)
+
+            # Respond to ping with pong
+            if "2" in self._split_messages(resp.text):
+                try:
+                    _post("3")
+                except Exception:
+                    pass
+
+        _LOGGER.info("Socket.IO: found passwords for %d/%d devices (%d polls)",
+                      len(passwords), len(serials_needed), poll_count)
+        return passwords
+
+    @staticmethod
+    def _split_messages(raw: str) -> list:
+        """Split EIO4 batched messages (separated by \\x1e)."""
+        if not raw:
+            return []
+        return raw.split("\x1e") if "\x1e" in raw else [raw]
+
+    def _extract_passwords(self, raw: str, passwords: dict, serials_needed: set):
+        """Parse Socket.IO messages for adapter_update events with passwords."""
+        for msg in self._split_messages(raw):
+            # Strip Engine.IO length prefix if present
+            if ":" in msg and msg.split(":")[0].isdigit():
+                msg = msg.split(":", 1)[1]
+
+            if not msg.startswith("42"):
+                continue
+
+            try:
+                payload = json.loads(msg[2:])
+            except (json.JSONDecodeError, IndexError):
+                continue
+
+            if (isinstance(payload, list) and len(payload) >= 2
+                    and payload[0] == "adapter_update"
+                    and isinstance(payload[1], dict)):
+                serial = payload[1].get("deviceSerial", "")
+                password = payload[1].get("password", "")
+                if serial in serials_needed and password:
+                    passwords[serial] = password
+                    _LOGGER.info("Got password for %s via adapter_update", serial)
+
+    # ── High-Level Credential Retrieval ─────────────────────
+
+    def get_all_device_credentials(self) -> dict:
+        """Retrieve credentials for all devices on this account.
+
+        Returns dict: serial -> {password, cryptoSerial, label, unitType, mac}
+        """
+        if not self._access_token and not self.login():
+            _LOGGER.warning("V3 login failed")
+            return {}
+
+        # Discover devices from sites/zones
+        devices = {}
+        for site in self.get_sites():
+            site_id = site.get("id")
+            if not site_id:
+                continue
+            for zone in self.get_zones(site_id):
+                adapter = zone.get("adapter", {})
+                serial = adapter.get("deviceSerial", "")
+                if serial:
+                    devices[serial] = {
+                        "label": zone.get("name", ""),
+                        "unitType": adapter.get("unitType", "ductless"),
+                        "mac": adapter.get("macAddress", ""),
+                        "serial": serial,
+                        "password": "",
+                        "cryptoSerial": "",
+                    }
+
+        if not devices:
+            _LOGGER.warning("No devices found via V3 API")
+            return {}
+
+        _LOGGER.info("V3 API: found %d devices", len(devices))
+
+        # Get cryptoSerials from status endpoint
+        for serial in devices:
+            status = self.get_device_status(serial)
+            if isinstance(status, dict):
+                crypto = status.get("cryptoSerial", "")
+                if crypto:
+                    devices[serial]["cryptoSerial"] = crypto
+
+        # Get passwords via Socket.IO
+        passwords = self.get_passwords_via_websocket(list(devices.keys()), timeout_secs=60)
+        for serial, password in passwords.items():
+            if serial in devices:
+                devices[serial]["password"] = password
+
+        has_crypto = sum(1 for d in devices.values() if d.get("cryptoSerial"))
+        has_pw = sum(1 for d in devices.values() if d.get("password"))
+        _LOGGER.info("V3 credentials: %d/%d cryptoSerial, %d/%d password",
+                      has_crypto, len(devices), has_pw, len(devices))
+
+        return devices

--- a/pykumo/py_kumo_discovery.py
+++ b/pykumo/py_kumo_discovery.py
@@ -1,0 +1,140 @@
+"""Local network discovery for Kumo WiFi adapters.
+
+Given candidate IP addresses (from HA DHCP discovery) and device credentials
+(from the V3 API), probes each IP with each device's credentials to determine
+which serial lives at which address.
+
+The Kumo WiFi adapters expose an HTTP API on port 80. A status query
+authenticated with the correct password + cryptoSerial returns valid JSON,
+confirming the serial-to-IP match. Wrong credentials return an error or empty
+response.
+"""
+
+import base64
+import hashlib
+import logging
+from typing import Dict, List
+
+import requests
+
+from .const import W_PARAM, S_PARAM
+
+_LOGGER = logging.getLogger(__name__)
+
+# Minimal status query for probing
+_PROBE_QUERY = b'{"c":{"indoorUnit":{"status":{}}}}'
+
+
+def probe_candidate_ips(devices: Dict[str, dict],
+                        candidate_ips: List[str],
+                        timeout: float = 3.0) -> Dict[str, str]:
+    """Probe candidate IPs to match device serials to addresses.
+
+    For each candidate IP, tries authenticating with each unmatched device's
+    credentials. A successful JSON response confirms the match.
+
+    Args:
+        devices: Dict of serial -> {password, cryptoSerial, ...} from V3 API.
+                 password is base64-encoded, cryptoSerial is a hex string.
+        candidate_ips: List of IP addresses to probe (e.g. from DHCP discovery).
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping serial -> IP address for successfully matched devices.
+    """
+    if not devices or not candidate_ips:
+        return {}
+
+    # Build decoded credentials for each device
+    device_creds = {}
+    for serial, dev in devices.items():
+        pw_b64 = dev.get("password", "")
+        crypto_hex = dev.get("cryptoSerial", "")
+        if not pw_b64 or not crypto_hex:
+            _LOGGER.debug("Skipping %s: missing credentials", serial)
+            continue
+        try:
+            device_creds[serial] = {
+                "password": base64.b64decode(pw_b64),
+                "crypto_serial": bytearray.fromhex(crypto_hex),
+            }
+        except Exception as ex:
+            _LOGGER.debug("Skipping %s: bad credentials: %s", serial, ex)
+
+    if not device_creds:
+        return {}
+
+    _LOGGER.info("Probing %d candidate IPs for %d devices",
+                 len(candidate_ips), len(device_creds))
+
+    result = {}
+    unmatched_serials = set(device_creds.keys())
+
+    for ip in candidate_ips:
+        if not unmatched_serials:
+            break
+
+        for serial in list(unmatched_serials):
+            creds = device_creds[serial]
+            if _probe_ip(ip, creds, timeout):
+                result[serial] = ip
+                unmatched_serials.discard(serial)
+                _LOGGER.info("Matched %s -> %s", serial, ip)
+                break  # This IP is claimed; move to next IP
+
+    if unmatched_serials:
+        _LOGGER.warning("Could not match %d/%d devices: %s",
+                        len(unmatched_serials), len(device_creds),
+                        list(unmatched_serials))
+    else:
+        _LOGGER.info("All %d devices matched to IPs", len(result))
+
+    return result
+
+
+def _compute_token(password: bytes, crypto_serial: bytearray,
+                   post_data: bytes) -> str:
+    """Compute the auth token for a local API request.
+
+    Replicates PyKumoBase._token() without needing a full instance.
+    """
+    data_hash = hashlib.sha256(password + post_data).digest()
+
+    intermediate = bytearray(88)
+    intermediate[0:32] = W_PARAM[0:32]
+    intermediate[32:64] = data_hash[0:32]
+    intermediate[64:66] = bytearray.fromhex("0840")
+    intermediate[66] = S_PARAM
+    intermediate[79] = crypto_serial[8]
+    intermediate[80:84] = crypto_serial[4:8]
+    intermediate[84:88] = crypto_serial[0:4]
+
+    return hashlib.sha256(intermediate).hexdigest()
+
+
+def _probe_ip(ip: str, creds: dict, timeout: float) -> bool:
+    """Try a status query against an IP with given credentials.
+
+    Returns True if the device responds with valid JSON containing expected
+    fields (meaning the credentials match this device).
+    """
+    url = f"http://{ip}/api"
+    token = _compute_token(creds["password"], creds["crypto_serial"],
+                           _PROBE_QUERY)
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Content-Type": "application/json",
+    }
+    try:
+        resp = requests.put(
+            url, headers=headers, data=_PROBE_QUERY,
+            params={"m": token}, timeout=timeout,
+        )
+        if resp.ok:
+            data = resp.json()
+            # A valid response has an "r" key with adapter/indoor unit data
+            if isinstance(data, dict) and "r" in data:
+                return True
+    except Exception:
+        pass
+    return False

--- a/pykumo/py_kumo_discovery.py
+++ b/pykumo/py_kumo_discovery.py
@@ -54,9 +54,14 @@ def probe_candidate_ips(devices: Dict[str, dict],
             _LOGGER.debug("Skipping %s: missing credentials", serial)
             continue
         try:
+            crypto = bytearray.fromhex(crypto_hex)
+            if len(crypto) < 9:
+                _LOGGER.debug("Skipping %s: cryptoSerial too short (%d bytes)",
+                              serial, len(crypto))
+                continue
             device_creds[serial] = {
                 "password": base64.b64decode(pw_b64),
-                "crypto_serial": bytearray.fromhex(crypto_hex),
+                "crypto_serial": crypto,
             }
         except Exception as ex:
             _LOGGER.debug("Skipping %s: bad credentials: %s", serial, ex)


### PR DESCRIPTION
Implements Kumo Cloud V3 API support for retrieving device credentials (cryptoSerial and password), addressing the breakage caused by the Mitsubishi Comfort app migration away from V2.

### V3 credential flow
- JWT authentication via `/v3/login` with token refresh
- REST endpoints for sites, zones, and device status (cryptoSerial)
- Socket.IO connection to `socket-prod.kumocloud.com` for real-time events (EIO4 protocol)
- Account-level and per-device subscriptions
- `force_adapter_request` triggers `adapter_update` containing device passwords

### Local network discovery
- Automatic discovery of Kumo WiFi adapters by probing DHCP lease files for known Kumo MAC prefixes (44:A7:CF, 38:B1:9E, etc.)
- Attempts credential retrieval via local HTTP API using known passwords
- `try_setup_v3_only()` accepts a `candidate_ips` dict (e.g. from Home Assistant's DHCP integration) to supplement lease-file discovery
- Enables setup without manually specifying device IPs, which is necessary for V3-only accounts where the cloud API no longer provides local network addresses

The existing V2 API path is retained as a fallback when V3 credentials are incomplete.

Relates to #56, #57, #58