### PR TITLE
Implement cycle-aware session management for connection pooling

### DIFF
--- a/pykumo/py_kumo.py
+++ b/pykumo/py_kumo.py
@@ -132,115 +132,122 @@ class PyKumo(PyKumoBase):
         """ Retrieve and cache current status dictionary if enough time
             has passed
         """
-        now = time.monotonic()
-        if (now - self._last_status_update > CACHE_INTERVAL_SECONDS or
-                'mode' not in self._status):
-            query = ['indoorUnit', 'status']
-            needed = ['mode', 'standby', 'spHeat', 'spCool', 'roomTemp',
-                      'fanSpeed', 'vaneDir', 'filterDirty', 'defrost']
-            # Following not currently used:
-            # 'tempSource', 'activeThermistor', 'hotAdjust', 'runTest'
-            response = self._retrieve_attributes(query, needed)
-            raw_status = response
-            try:
-                self._status = raw_status['r']['indoorUnit']['status']
-                self._last_status_update = now
-            except KeyError as ke:
-                _LOGGER.warning(f"{self._name}: Error retrieving status from {response}: "
-                                f"{str(ke)}")
-                return False
-
-            self._sensors = []
-            for s in range(POSSIBLE_SENSORS):
-                s_str = f'{s}'
-                query = ['sensors', s_str]
-                needed = ['uuid', 'humidity', 'temperature', 'battery', 'rssi', 'txPower']
-
+        
+        # Use cycle-aware session management to optimize multiple requests during status update, 
+        # then close session at the end of the cycle to send a clean FIN to the adapter.
+        self.begin_cycle()
+        try:
+            now = time.monotonic()
+            if (now - self._last_status_update > CACHE_INTERVAL_SECONDS or
+                    'mode' not in self._status):
+                query = ['indoorUnit', 'status']
+                needed = ['mode', 'standby', 'spHeat', 'spCool', 'roomTemp',
+                          'fanSpeed', 'vaneDir', 'filterDirty', 'defrost']
+                # Following not currently used:
+                # 'tempSource', 'activeThermistor', 'hotAdjust', 'runTest'
                 response = self._retrieve_attributes(query, needed)
-
+                raw_status = response
                 try:
-                    sensor = response['r']['sensors'][s_str]
-                    if isinstance(sensor, dict) and sensor.get('uuid'):
-                        self._sensors.append(sensor)
-                    else:
-                        # No sensor found at this index; skip the rest
-                        break
+                    self._status = raw_status['r']['indoorUnit']['status']
+                    self._last_status_update = now
                 except KeyError as ke:
-                    _LOGGER.warning(f"{self._name}: Error retrieving sensors from {response}: "
+                    _LOGGER.warning(f"{self._name}: Error retrieving status from {response}: "
                                     f"{str(ke)}")
                     return False
 
-            query = ['indoorUnit', 'profile']
-            needed = ['numberOfFanSpeeds', 'hasFanSpeedAuto', 'hasVaneSwing', 'hasModeDry',
-                      'hasModeHeat', 'hasModeVent', 'hasModeAuto', 'hasVaneDir']
-            # Following not currently used
-            # 'extendedTemps', 'usesSetPointInDryMode', 'hasHotAdjust', 'hasDefrost',
-            # 'hasStandby', 'maximumSetPoints', 'minimumSetPoints'
-            response = self._retrieve_attributes(query, needed)
-            try:
-                self._profile = response['r']['indoorUnit']['profile']
-            except KeyError as ke:
-                _LOGGER.warning(f"{self._name}: Error retrieving profile from {response}: "
-                                f"{str(ke)}")
-                return False
+                self._sensors = []
+                for s in range(POSSIBLE_SENSORS):
+                    s_str = f'{s}'
+                    query = ['sensors', s_str]
+                    needed = ['uuid', 'humidity', 'temperature', 'battery', 'rssi', 'txPower']
 
-            # Edit profile with settings from adapter
-            query = ['adapter', 'status']
-            needed = ['autoModePrevention', 'userHasModeDry', 'userHasModeHeat',
-                      'localNetwork', 'runState']
-            # Following not currently used:
-            # 'name', 'roomTempOffset', 'userMinCoolSetPoint', 'userMaxHeatSetPoint',
-            # 'ledDisabled', 'serverHostname'
-            # ['adapter', 'info'] not used:
-            # ['macAddress', 'serialNumber', 'isTestMode', 'firmwareVersion']
-            response = self._retrieve_attributes(query, needed)
-            try:
-                status = response['r']['adapter']['status']
-                self._profile['hasModeAuto'] = not status.get(
-                    'autoModePrevention', False)
-                if not status.get('userHasModeDry', False):
-                    self._profile['hasModeDry'] = False
-                if not status.get('userHasModeHeat', False):
-                    self._profile['hasModeHeat'] = False
+                    response = self._retrieve_attributes(query, needed)
+
+                    try:
+                        sensor = response['r']['sensors'][s_str]
+                        if isinstance(sensor, dict) and sensor.get('uuid'):
+                            self._sensors.append(sensor)
+                        else:
+                            # No sensor found at this index; skip the rest
+                            break
+                    except KeyError as ke:
+                        _LOGGER.warning(f"{self._name}: Error retrieving sensors from {response}: "
+                                        f"{str(ke)}")
+                        return False
+
+                query = ['indoorUnit', 'profile']
+                needed = ['numberOfFanSpeeds', 'hasFanSpeedAuto', 'hasVaneSwing', 'hasModeDry',
+                          'hasModeHeat', 'hasModeVent', 'hasModeAuto', 'hasVaneDir']
+                # Following not currently used
+                # 'extendedTemps', 'usesSetPointInDryMode', 'hasHotAdjust', 'hasDefrost',
+                # 'hasStandby', 'maximumSetPoints', 'minimumSetPoints'
+                response = self._retrieve_attributes(query, needed)
                 try:
-                    self._profile['wifiRSSI'] = (
-                        status['localNetwork']['stationMode']['RSSI'])
-                except KeyError:
-                    self._profile['wifiRSSI'] = None
-                self._profile['runState'] = status.get('runState', "unknown")
-            except KeyError as ke:
-                _LOGGER.warning(f"{self._name}: Error retrieving adapter profile from {response}: "
-                                f"{str(ke)}")
-                return False
+                    self._profile = response['r']['indoorUnit']['profile']
+                except KeyError as ke:
+                    _LOGGER.warning(f"{self._name}: Error retrieving profile from {response}: "
+                                    f"{str(ke)}")
+                    return False
 
-            # Edit profile with data from MHK2 if present
-            query = '{"c":{"mhk2":{"status":{}}}}'.encode('utf-8')
-            response = self._request(query)
-            try:
-                self._mhk2 = response['r']['mhk2']
-                if isinstance(self._mhk2, dict):
-                    mhk2_humidity = self._mhk2['status']['indoorHumid']
+                # Edit profile with settings from adapter
+                query = ['adapter', 'status']
+                needed = ['autoModePrevention', 'userHasModeDry', 'userHasModeHeat',
+                          'localNetwork', 'runState']
+                # Following not currently used:
+                # 'name', 'roomTempOffset', 'userMinCoolSetPoint', 'userMaxHeatSetPoint',
+                # 'ledDisabled', 'serverHostname'
+                # ['adapter', 'info'] not used:
+                # ['macAddress', 'serialNumber', 'isTestMode', 'firmwareVersion']
+                response = self._retrieve_attributes(query, needed)
+                try:
+                    status = response['r']['adapter']['status']
+                    self._profile['hasModeAuto'] = not status.get(
+                        'autoModePrevention', False)
+                    if not status.get('userHasModeDry', False):
+                        self._profile['hasModeDry'] = False
+                    if not status.get('userHasModeHeat', False):
+                        self._profile['hasModeHeat'] = False
+                    try:
+                        self._profile['wifiRSSI'] = (
+                            status['localNetwork']['stationMode']['RSSI'])
+                    except KeyError:
+                        self._profile['wifiRSSI'] = None
+                    self._profile['runState'] = status.get('runState', "unknown")
+                except KeyError as ke:
+                    _LOGGER.warning(f"{self._name}: Error retrieving adapter profile from {response}: "
+                                    f"{str(ke)}")
+                    return False
 
-                    if mhk2_humidity is not None:
-                        # Add a sensor entry for the MHK2 unit.
-                        mhk2_sensor_value = {
-                            'battery': None,
-                            'humidity': mhk2_humidity,
-                            'rssi': None,
-                            'temperature': None,
-                            'txPower': None,
-                            'uuid': None
-                        }
-                        self._sensors.append(mhk2_sensor_value)
-            except (KeyError, TypeError) as e:
-                # We don't bailout here since the MHK2 component is optional.
-                _LOGGER.info(f"{self._name}: Error retrieving MHK2 status from {response}: {e}")
-                pass
+                # Edit profile with data from MHK2 if present
+                query = '{"c":{"mhk2":{"status":{}}}}'.encode('utf-8')
+                response = self._request(query)
+                try:
+                    self._mhk2 = response['r']['mhk2']
+                    if isinstance(self._mhk2, dict):
+                        mhk2_humidity = self._mhk2['status']['indoorHumid']
 
-        if self._unit_schedule is not None:
-            self._unit_schedule.fetch()
+                        if mhk2_humidity is not None:
+                            # Add a sensor entry for the MHK2 unit.
+                            mhk2_sensor_value = {
+                                'battery': None,
+                                'humidity': mhk2_humidity,
+                                'rssi': None,
+                                'temperature': None,
+                                'txPower': None,
+                                'uuid': None
+                            }
+                            self._sensors.append(mhk2_sensor_value)
+                except (KeyError, TypeError) as e:
+                    # We don't bailout here since the MHK2 component is optional.
+                    _LOGGER.info(f"{self._name}: Error retrieving MHK2 status from {response}: {e}")
+                    pass
 
-        return True
+            if self._unit_schedule is not None:
+                self._unit_schedule.fetch()
+
+            return True
+        finally:
+            self.end_cycle()
 
     def get_mode(self):
         """ Last retrieved operating mode from unit """

--- a/pykumo/py_kumo_base.py
+++ b/pykumo/py_kumo_base.py
@@ -3,16 +3,74 @@
 
 import hashlib
 import base64
+import json
 import time
 import logging
+import threading
 import requests
-from urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 from requests.exceptions import Timeout
 from .const import (CACHE_INTERVAL_SECONDS, W_PARAM, S_PARAM, UNIT_CONNECT_TIMEOUT_SECONDS,
                     UNIT_RESPONSE_TIMEOUT_SECONDS)
 
 _LOGGER = logging.getLogger(__name__)
+
+# threading.local is used instead of storing the session on self because
+# hass-kumo dispatches pykumo calls via HA's shared ThreadPoolExecutor
+# (async_add_executor_job), meaning the same PyKumo instance can land on
+# different threads across successive calls. requests.Session is not
+# thread-safe, so a per-thread store is required.
+_tl = threading.local()
+
+
+def _get_session(address: str) -> requests.Session:
+    """Return a persistent Session for (current_thread, address).
+
+    Creates a new Session on first access per thread. pool_connections=1
+    and pool_maxsize=1 with pool_block=True ensure urllib3 never silently
+    opens secondary connections under contention — this guarantees exactly
+    one TCP connection per (thread, unit) at any given time.
+    """
+    if not hasattr(_tl, "sessions"):
+        _tl.sessions = {}
+
+    session = _tl.sessions.get(address)
+    if session is None:
+        _LOGGER.debug(
+            "Opening Session for %s on thread %s",
+            address, threading.current_thread().name
+        )
+        session = requests.Session()
+        adapter = HTTPAdapter(
+            max_retries=0,         # we handle retries ourselves
+            pool_connections=1,
+            pool_maxsize=1,
+            pool_block=True,       # serialize rather than opening a second conn
+        )
+        session.mount("http://", adapter)
+        _tl.sessions[address] = session
+
+    return session
+
+
+def _drop_session(address: str) -> None:
+    """Close and discard the thread-local session for address.
+
+    session.close() closes all pooled connections, sending a FIN on any
+    that are still idle in the pool. This tells the adapter to free its
+    socket-table entry immediately rather than waiting for idle timeout.
+    """
+    sessions = getattr(_tl, "sessions", {})
+    session = sessions.pop(address, None)
+    if session is not None:
+        try:
+            session.close()
+        except Exception:
+            pass
+        _LOGGER.debug(
+            "Closed Session for %s on thread %s",
+            address, threading.current_thread().name
+        )
 
 
 class PyKumoBase:
@@ -43,6 +101,14 @@ class PyKumoBase:
         self._sensors = []
         self._last_status_update = time.monotonic() - 2 * CACHE_INTERVAL_SECONDS
 
+        # Cycle context: when True, _request keeps the session open across
+        # calls for keep-alive reuse. When False, each _request closes the
+        # session immediately after the response. Multi-request operations
+        # like update_status wrap themselves in a cycle via begin_cycle()
+        # / end_cycle(). Single-shot operations (set_mode, etc.) leave
+        # this False and get immediate FIN after each call.
+        self._in_cycle = False
+
     def _token(self, post_data):
         """ Compute URL including security token for a given command
         """
@@ -62,30 +128,124 @@ class PyKumoBase:
 
         return token
 
+    @staticmethod
+    def _cleanup_response(response) -> None:
+        """Defensively close a response that may be in an indeterminate
+        state. Silently swallows any exception — this runs in error
+        handlers where we must not raise.
+        """
+        if response is None:
+            return
+        try:
+            response.close()
+        except Exception:
+            pass
+
+    def begin_cycle(self):
+        """Mark the start of a multi-request cycle. Subsequent _request
+        calls will reuse the same TCP connection (keep-alive) until
+        end_cycle() is called. Safe to call multiple times; idempotent.
+        """
+        self._in_cycle = True
+
+    def end_cycle(self):
+        """Mark the end of a multi-request cycle and close the session.
+        Sends a FIN to the adapter, freeing its socket-table entry.
+        Safe to call multiple times; idempotent.
+        """
+        self._in_cycle = False
+        _drop_session(self._address)
+
+    def close(self):
+        """Close any open HTTP session to this unit. Alias for end_cycle()
+        that reads more naturally from callers that aren't managing a
+        cycle explicitly.
+        """
+        self.end_cycle()
+
     def _request(self, post_data):
-        """ Send request to configured unit and return response dict
+        """ Send request to configured unit and return response dict.
+
+        Connection lifecycle:
+        - Inside a cycle (begin_cycle() called): keep the session open
+          for reuse by subsequent calls in the same cycle.
+        - Outside a cycle: close the session immediately after the
+          response, sending a clean FIN to the adapter.
+
+        Hardening:
+        - Body fully drained before JSON parsing (no abandoned sockets on malformed responses)
+        - response.close() in every exit path
+        - Session dropped on ANY transport error
+        - One retry on transport error with a fresh session
         """
         if not self._address:
             _LOGGER.warning("Unit %s address not set", self._name)
             return {}
+
         url = "http://" + self._address + "/api"
         token = self._token(post_data)
-        headers = {'Accept': 'application/json, text/plain, */*',
-                   'Content-Type': 'application/json'}
+        headers = {
+            'Accept': 'application/json, text/plain, */*',
+            'Content-Type': 'application/json',
+        }
         token_param = {'m': token}
-        try:
-            with requests.Session() as session:
-                retries = Retry(total=3, backoff_factor=0.1)
-                session.mount('http://', HTTPAdapter(max_retries=retries))
-                _LOGGER.debug("Issue request %s %s", url, post_data)
+
+        for attempt in range(2):
+            session = _get_session(self._address)
+            response = None
+            try:
+                _LOGGER.debug("Issue request %s %s (attempt %d)", url, post_data, attempt)
                 response = session.put(
-                    url, headers=headers, data=post_data, params=token_param,
-                    timeout=self._timeouts)
-                return response.json()
-        except Timeout as ex:
-            _LOGGER.warning("Timeout issuing request %s: %s", url, str(ex))
-        except Exception as ex:
-            _LOGGER.warning("Error issuing request %s: %s", url, str(ex))
+                    url,
+                    headers=headers,
+                    data=post_data,
+                    params=token_param,
+                    timeout=self._timeouts,
+                )
+
+                # Drain body BEFORE parsing. If JSON parsing fails, the
+                # body is already fully read so urllib3 can return the
+                # connection to the pool cleanly rather than abandoning it.
+                content = response.content
+                response.close()
+                response = None
+
+                result = json.loads(content.decode('utf-8'))
+
+                # Close the session if this is a single-shot call
+                # (outside any multi-request cycle).
+                if not self._in_cycle:
+                    _drop_session(self._address)
+
+                return result
+
+            except Timeout as ex:
+                _LOGGER.warning("Timeout issuing request %s: %s", url, str(ex))
+                self._cleanup_response(response)
+                # A timeout means the connection state is unknowable —
+                # drop it rather than risk reusing a half-dead socket.
+                _drop_session(self._address)
+                return {}
+
+            except (json.JSONDecodeError, ValueError) as ex:
+                _LOGGER.warning(
+                    "Malformed response from %s: %s", url, str(ex)
+                )
+                self._cleanup_response(response)
+                _drop_session(self._address)
+                return {}
+
+            except Exception as ex:
+                _LOGGER.debug(
+                    "Request error on attempt %d for %s: %s (%s)",
+                    attempt, url, str(ex), type(ex).__name__
+                )
+                self._cleanup_response(response)
+                _drop_session(self._address)
+                if attempt == 1:
+                    _LOGGER.warning("Error issuing request %s: %s", url, str(ex))
+                    return {}
+
         return {}
 
     def get_status(self):

--- a/pykumo/py_kumo_base.py
+++ b/pykumo/py_kumo_base.py
@@ -101,13 +101,6 @@ class PyKumoBase:
         self._sensors = []
         self._last_status_update = time.monotonic() - 2 * CACHE_INTERVAL_SECONDS
 
-        # Cycle context: when True, _request keeps the session open across
-        # calls for keep-alive reuse. When False, each _request closes the
-        # session immediately after the response. Multi-request operations
-        # like update_status wrap themselves in a cycle via begin_cycle()
-        # / end_cycle(). Single-shot operations (set_mode, etc.) leave
-        # this False and get immediate FIN after each call.
-        self._in_cycle = False
 
     def _token(self, post_data):
         """ Compute URL including security token for a given command
@@ -145,15 +138,21 @@ class PyKumoBase:
         """Mark the start of a multi-request cycle. Subsequent _request
         calls will reuse the same TCP connection (keep-alive) until
         end_cycle() is called. Safe to call multiple times; idempotent.
+
+        Cycle state is stored thread-locally so concurrent threads calling
+        into the same PyKumoBase instance each manage their own lifecycle
+        independently.
         """
-        self._in_cycle = True
+        if not hasattr(_tl, "cycles"):
+            _tl.cycles = set()
+        _tl.cycles.add(self._address)
 
     def end_cycle(self):
         """Mark the end of a multi-request cycle and close the session.
         Sends a FIN to the adapter, freeing its socket-table entry.
         Safe to call multiple times; idempotent.
         """
-        self._in_cycle = False
+        getattr(_tl, "cycles", set()).discard(self._address)
         _drop_session(self._address)
 
     def close(self):
@@ -214,18 +213,23 @@ class PyKumoBase:
 
                 # Close the session if this is a single-shot call
                 # (outside any multi-request cycle).
-                if not self._in_cycle:
+                if self._address not in getattr(_tl, "cycles", set()):
                     _drop_session(self._address)
 
                 return result
 
             except Timeout as ex:
-                _LOGGER.warning("Timeout issuing request %s: %s", url, str(ex))
+                _LOGGER.debug(
+                    "Timeout on attempt %d for %s: %s", attempt, url, str(ex)
+                )
                 self._cleanup_response(response)
                 # A timeout means the connection state is unknowable —
                 # drop it rather than risk reusing a half-dead socket.
                 _drop_session(self._address)
-                return {}
+                if attempt == 1:
+                    _LOGGER.warning("Timeout issuing request %s: %s", url, str(ex))
+                    return {}
+                # attempt == 0: fall through to retry with a fresh session
 
             except (json.JSONDecodeError, ValueError) as ex:
                 _LOGGER.warning(


### PR DESCRIPTION
- Add thread-local persistent HTTP sessions keyed by unit address
- Sessions reuse TCP connections (keep-alive) within multi-request cycles
- Single-shot operations (set_mode, etc.) close immediately for clean FIN
- Wrap update_status() in begin_cycle()/end_cycle() to optimize sensor/profile queries
- Thread-safe design handles concurrent calls via HA's ThreadPoolExecutor
- Graceful session cleanup with explicit FIN packets

Improves performance by reducing TCP handshake overhead during status updates while maintaining clean connection state for adapter compatibility.

Outcome validation after 24h:
- No more connection errors reported in HASS.
- tcpdump confirms FIN packets sent after each cycle and single-shot request.
- tcpdump shows that the controller appears -more- responsive with reduced latency on socket responses after 24h.