### PR TITLE
Treat 'auto' setpoints as ground truth for has_mode_auto

### DIFF
--- a/pykumo/py_kumo.py
+++ b/pykumo/py_kumo.py
@@ -128,6 +128,21 @@ class PyKumo(PyKumoBase):
                 "Exception fetching %s: %s", base_query, str(e))
         return response
 
+    def _compute_has_mode_auto(self, auto_mode_prevention: bool) -> bool:
+        """ True if the unit supports auto (heat/cool) mode.
+
+        Honors the adapter's autoModePrevention flag, but falls back to the
+        unit profile's auto setpoints, since some installer configurations
+        set autoModePrevention=True even though the unit (and the Mitsubishi
+        Comfort app) treat auto mode as supported. Checks both
+        maximumSetPoints and minimumSetPoints for an 'auto' key.
+        """
+        if not auto_mode_prevention:
+            return True
+        max_sp = self._profile.get('maximumSetPoints', {}) or {}
+        min_sp = self._profile.get('minimumSetPoints', {}) or {}
+        return 'auto' in max_sp or 'auto' in min_sp
+
     def update_status(self):
         """ Retrieve and cache current status dictionary if enough time
             has passed
@@ -177,10 +192,11 @@ class PyKumo(PyKumoBase):
 
                 query = ['indoorUnit', 'profile']
                 needed = ['numberOfFanSpeeds', 'hasFanSpeedAuto', 'hasVaneSwing', 'hasModeDry',
-                          'hasModeHeat', 'hasModeVent', 'hasModeAuto', 'hasVaneDir']
+                          'hasModeHeat', 'hasModeVent', 'hasModeAuto', 'hasVaneDir',
+                          'maximumSetPoints', 'minimumSetPoints']
                 # Following not currently used
                 # 'extendedTemps', 'usesSetPointInDryMode', 'hasHotAdjust', 'hasDefrost',
-                # 'hasStandby', 'maximumSetPoints', 'minimumSetPoints'
+                # 'hasStandby'
                 response = self._retrieve_attributes(query, needed)
                 try:
                     self._profile = response['r']['indoorUnit']['profile']
@@ -201,8 +217,8 @@ class PyKumo(PyKumoBase):
                 response = self._retrieve_attributes(query, needed)
                 try:
                     status = response['r']['adapter']['status']
-                    self._profile['hasModeAuto'] = not status.get(
-                        'autoModePrevention', False)
+                    self._profile['hasModeAuto'] = self._compute_has_mode_auto(
+                        status.get('autoModePrevention', False))
                     if not status.get('userHasModeDry', False):
                         self._profile['hasModeDry'] = False
                     if not status.get('userHasModeHeat', False):


### PR DESCRIPTION
## Summary

Moves the auto-mode detection logic from the integration ([hass-kumo #204](https://github.com/dlarrick/hass-kumo/pull/204)) into pykumo, where the `update_status` adapter-section already computes `self._profile['hasModeAuto']`.

The adapter's `autoModePrevention` flag can incorrectly suppress auto (heat/cool) mode even when the unit supports it — some installer configurations set `autoModePrevention=True` while the Mitsubishi Comfort app and the cloud-based Comfort integration both still expose auto mode. The unit profile's auto setpoints are a more reliable indicator: if `maximumSetPoints` or `minimumSetPoints` contains an `'auto'` key (e.g. `{'cool': 30, 'heat': 28, 'auto': 28}`), the unit supports auto mode regardless of the adapter-level flag.

## Changes

- New private helper `PyKumo._compute_has_mode_auto(auto_mode_prevention)` that:
  - returns `True` when `autoModePrevention` is `False` (preserves existing behavior),
  - falls back to checking for `'auto'` in either `maximumSetPoints` or `minimumSetPoints` when `autoModePrevention` is `True`.
- `update_status` calls the helper instead of computing `hasModeAuto` inline, keeping the surrounding code untouched.
- Adds `maximumSetPoints` and `minimumSetPoints` to the `needed` list of the `indoorUnit/profile` query, so the helper has the data it needs even on the individual-attribute fallback path inside `_retrieve_attributes`. (They were previously listed under \"not currently used\".)

## Why this lives in pykumo

Per [@dlarrick's review on hass-kumo #204](https://github.com/dlarrick/hass-kumo/pull/204#discussion_r2191290847): \"Could you please update the logic in pykumo that sets `self._profile['hasModeAuto']` instead of overriding it here? Maybe write a small private member function.\" That's what this is.

## Why both `maximumSetPoints` and `minimumSetPoints`

Per [Copilot's review on the same line](https://github.com/dlarrick/hass-kumo/pull/204#discussion_r2191290819): some profiles may expose the `auto` key only under `minimumSetPoints` (or vice versa), and checking only `maximumSetPoints` would still suppress `heat_cool` for those units. The helper checks both.

## Testing

pykumo doesn't currently have a test harness, so this is verified end-to-end on a live unit:

- Mitsubishi mini-split with `autoModePrevention=True` on the adapter and `'auto'` present in `maximumSetPoints`.
- With this branch installed via a hass-kumo manifest pin (`pykumo @ git+...`) and the existing PR #204 override removed from `climate.py`, Home Assistant exposes `heat_cool` mode and the unit operates correctly in auto mode end-to-end.
- Round-trip mode changes verified in both directions: HomeKit → HA → Kumo, and physical thermostat → Kumo poll → HA. State, `target_temp_low`/`target_temp_high`, `hvac_action`, and `current_temperature` all reflect the unit accurately.
- No new errors in HA's `system_log` for `kumo`/`pykumo` after the change.

## Companion PR

Once this is released, [hass-kumo #204](https://github.com/dlarrick/hass-kumo/pull/204) will be reduced to a manifest version bump and removal of the now-redundant `climate.py` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)