### PR TITLE
Add PyKumoBase.has_profile() to expose profile-populated state

### DIFF
--- a/pykumo/py_kumo_base.py
+++ b/pykumo/py_kumo_base.py
@@ -262,6 +262,19 @@ class PyKumoBase:
 
         return {}
 
+    def has_profile(self) -> bool:
+        """Return True if the unit profile has been populated from a successful poll.
+
+        The profile starts as an empty dict at construction and is populated after
+        the first successful ``update_status()`` call. Consumers (e.g. hass-kumo)
+        should call this before relying on capability methods such as
+        ``has_auto_mode()``, ``has_heat_mode()``, or ``get_fan_speeds()``:
+        those methods silently return defaults (``False`` / a fallback list) when
+        the profile is empty, which can cause incorrect behaviour if cached at
+        initialisation time while the adapter is temporarily offline.
+        """
+        return bool(self._profile)
+
     def get_status(self):
         """Last retrieved status dictionary from unit"""
         return self._status

--- a/tests/test_py_kumo_base.py
+++ b/tests/test_py_kumo_base.py
@@ -1,0 +1,43 @@
+"""Tests for PyKumoBase.has_profile()."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pykumo.py_kumo_base import PyKumoBase
+
+
+# Minimal cfg_json accepted by PyKumoBase.__init__
+_CFG = {
+    "password": "dGVzdA==",  # base64("test")
+    "crypto_serial": "0123456789ABCDEF01234567",
+}
+
+
+class TestHasProfile(unittest.TestCase):
+    """PyKumoBase.has_profile() behaviour."""
+
+    def _make_unit(self):
+        return PyKumoBase("Test Unit", "192.168.1.1", _CFG)
+
+    def test_false_before_any_poll(self):
+        """has_profile() is False immediately after construction."""
+        unit = self._make_unit()
+        self.assertFalse(unit.has_profile())
+
+    def test_true_after_profile_populated(self):
+        """has_profile() is True once _profile contains real data."""
+        unit = self._make_unit()
+        unit._profile = {"hasModeAuto": True, "numberOfFanSpeeds": 5}
+        self.assertTrue(unit.has_profile())
+
+    def test_false_when_profile_reset_to_empty(self):
+        """has_profile() returns False again if profile is cleared."""
+        unit = self._make_unit()
+        unit._profile = {"hasModeAuto": True}
+        self.assertTrue(unit.has_profile())
+        unit._profile = {}
+        self.assertFalse(unit.has_profile())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_py_kumo_base.py
+++ b/tests/test_py_kumo_base.py
@@ -1,7 +1,6 @@
 """Tests for PyKumoBase.has_profile()."""
 
 import unittest
-from unittest.mock import MagicMock, patch
 
 from pykumo.py_kumo_base import PyKumoBase
 


### PR DESCRIPTION
## Summary

Add a one-line public method `has_profile() -> bool` to `PyKumoBase` that tells callers whether the unit profile has been populated from a successful poll.

## Motivation

`_profile` starts as `{}` at construction and is populated after the first successful `update_status()` call. Capability methods — `has_auto_mode()`, `has_heat_mode()`, `get_fan_speeds()`, `get_vane_directions()`, etc. — all read `_profile` and return **silent defaults** (`False` / a hardcoded fallback list) when the profile is empty. A truthiness check on their return values cannot distinguish real hardware data from those defaults.

Consumers that derive capability lists (e.g. which HVAC modes are supported) and cache the result need a reliable way to know whether the profile is populated before trusting capability output. Without this, capabilities derived before the first successful poll (e.g. when the WiFi adapter is offline at startup) are silently wrong and never corrected.

This is the exact scenario described in hass-kumo PR [#223](https://github.com/dlarrick/hass-kumo/pull/223), which currently works around it via `self._pykumo._profile` — a direct reach into a private attribute.

## Change

```python
# py_kumo_base.py — PyKumoBase

def has_profile(self) -> bool:
    """Return True if the unit profile has been populated from a successful poll.
    ...
    """
    return bool(self._profile)
```

3 unit tests added in `tests/test_py_kumo_base.py`.

## Relationship to hass-kumo

hass-kumo PR dlarrick/hass-kumo#223 adds a profile-populated guard before refreshing HVAC capabilities. Once this method is available and released, that PR can replace `self._pykumo._profile` with `self._pykumo.has_profile()` and bump the `pykumo` requirement accordingly.