### PR TITLE
Add external temp sensor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To restore the unit's own return-air sensor:
 unit.set_temp_source('returnair')
 ```
 
-Writes are applied asynchronously, so the response may have stale value if queried immediately. Re-send the temperature periodically (roughly every 20 seconds) to keep it fresh. activeThermistor will report what temp source is currently in effect. If an updated temp is not supplied in a while, the device will auto fallback to using the internal thermistor.
+Writes are applied asynchronously, so the response may have a stale value if queried immediately. Re-send the temperature periodically (roughly every 20 seconds) to keep it fresh. activeThermistor reports which temp source is currently in effect. If an updated temperature is not supplied for a while, the device automatically falls back to using the internal thermistor.
 
 
 Note that the temperature source setting persists across adapter reboots, so be sure to restore it when you're done.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ If an indoor unit is reachable but returns error responses to legitimate command
 unit.do_reboot()
 ```
 
+### Use an external temperature sensor
+The WiFi adapter can source its room temperature reading from the API instead of a physical thermistor. This lets you use an external sensor of your choice as the unit's temperature input.
+
+```
+unit.set_temp_source('api')
+unit.set_injected_room_temp(18.5)
+```
+
+To restore the unit's own return-air sensor:
+```
+unit.set_temp_source('returnair')
+```
+
+Writes are applied asynchronously, so the response may have stale value if queried immediately. Re-send the temperature periodically (roughly every 20 seconds) to keep it fresh. activeThermistor will report what temp source is currently in effect. If an updated temp is not supplied in a while, the device will auto fallback to using the internal thermistor.
+
+
+Note that the temperature source setting persists across adapter reboots, so be sure to restore it when you're done.
+
 ### Query or Command an Indoor Unit Directly
 Indoor units speak a simple protocol of nested JSON. I'm not documenting the protocol here (though documentation patches would be welcome!), but if you look through the `pykumo.py` code for calls to `self._request` you can see the queries and commands that are already enabled. For example:
 ```

--- a/pykumo/const.py
+++ b/pykumo/const.py
@@ -16,3 +16,16 @@ KUMO_CONNECT_TIMEOUT_SECONDS = 5
 KUMO_RESPONSE_TIMEOUT_SECONDS = 60
 
 POSSIBLE_SENSORS = 4
+
+# Valid tempSource values. "unset" is reported by the adapter but rejected on write.
+TEMP_SOURCES = [
+    "sensor0",
+    "sensor1",
+    "sensor2",
+    "sensor3",
+    "returnair",
+    "remote",
+    "api",
+    "unset",
+]
+SETTABLE_TEMP_SOURCES = [s for s in TEMP_SOURCES if s != "unset"]

--- a/pykumo/const.py
+++ b/pykumo/const.py
@@ -18,11 +18,7 @@ KUMO_RESPONSE_TIMEOUT_SECONDS = 60
 POSSIBLE_SENSORS = 4
 
 # Valid tempSource values. "unset" is reported by the adapter but rejected on write.
-TEMP_SOURCES = [
-    "sensor0",
-    "sensor1",
-    "sensor2",
-    "sensor3",
+TEMP_SOURCES = [f"sensor{i}" for i in range(POSSIBLE_SENSORS)] + [
     "returnair",
     "remote",
     "api",

--- a/pykumo/py_kumo.py
+++ b/pykumo/py_kumo.py
@@ -698,16 +698,17 @@ class PyKumo(PyKumoBase):
         self._last_status_update = time.monotonic() - 2 * CACHE_INTERVAL_SECONDS
         return response
 
-    def set_injected_room_temp(self, temperature):
+def set_injected_room_temp(self, temperature):
         """Inject a room temperature for the unit to use.
-        only used if tempSource is set to 'api'.
-        The caller must re-send the value periodically to prevent the
-        system from ignoring it as stale.
+
+        Only used if tempSource is set to "api". The caller must re-send the value
+        periodically to prevent the system from ignoring it as stale.
         """
-        if self.get_temp_source() != "api":
+        temp_source = self.get_temp_source()
+        if temp_source != "api":
             _LOGGER.warning(
                 "Ignoring injected room temp; tempSource is %s, not 'api'",
-                self.get_temp_source(),
+                temp_source,
             )
             return {}
         temperature = round(float(temperature), 1)

--- a/pykumo/py_kumo.py
+++ b/pykumo/py_kumo.py
@@ -7,7 +7,7 @@ from collections.abc import MutableMapping
 
 from .schedule import UnitSchedule
 
-from .const import CACHE_INTERVAL_SECONDS, POSSIBLE_SENSORS
+from .const import CACHE_INTERVAL_SECONDS, POSSIBLE_SENSORS, SETTABLE_TEMP_SOURCES
 from .py_kumo_base import PyKumoBase
 
 _LOGGER = logging.getLogger(__name__)
@@ -194,9 +194,11 @@ class PyKumo(PyKumoBase):
                     "vaneDir",
                     "filterDirty",
                     "defrost",
+                    "tempSource",
+                    "activeThermistor",
                 ]
                 # Following not currently used:
-                # 'tempSource', 'activeThermistor', 'hotAdjust', 'runTest'
+                # 'hotAdjust', 'runTest'
                 response = self._retrieve_attributes(query, needed)
                 raw_status = response
                 try:
@@ -371,6 +373,24 @@ class PyKumo(PyKumoBase):
         """Last retrieved current temperature from unit"""
         try:
             val = self._status["roomTemp"]
+        except KeyError:
+            val = None
+        return val
+
+    def get_temp_source(self):
+        """Last retrieved temperature source from unit"""
+        try:
+            val = self._status["tempSource"]
+        except KeyError:
+            val = None
+        return val
+
+    def get_active_thermistor(self):
+        """Last retrieved active thermistor from unit. Reports 'api' while an
+        injected room temperature is live.
+        """
+        try:
+            val = self._status["activeThermistor"]
         except KeyError:
             val = None
         return val
@@ -660,6 +680,42 @@ class PyKumo(PyKumoBase):
         ).encode("utf-8")
         response = self._request(command)
         self._status["vaneDir"] = direction
+        self._last_status_update = time.monotonic() - 2 * CACHE_INTERVAL_SECONDS
+        return response
+
+    def set_temp_source(self, source):
+        """Change temperature source. Valid sources: sensor0-sensor3,
+        returnair, remote, api.
+        """
+        if source not in SETTABLE_TEMP_SOURCES:
+            _LOGGER.warning("Attempting to set invalid temp source %s", source)
+            return {}
+        command = (
+            '{"c": { "indoorUnit": { "status": { "tempSource": "%s" } } } }' % source
+        ).encode("utf-8")
+        response = self._request(command)
+        self._status["tempSource"] = source
+        self._last_status_update = time.monotonic() - 2 * CACHE_INTERVAL_SECONDS
+        return response
+
+    def set_injected_room_temp(self, temperature):
+        """Inject a room temperature for the unit to use.
+        only used if tempSource is set to 'api'.
+        The caller must re-send the value periodically to prevent the
+        system from ignoring it as stale.
+        """
+        if self.get_temp_source() != "api":
+            _LOGGER.warning(
+                "Ignoring injected room temp; tempSource is %s, not 'api'",
+                self.get_temp_source(),
+            )
+            return {}
+        temperature = round(float(temperature), 1)
+        command = (
+            '{"c": { "indoorUnit": { "status": { "roomTemp": %.1f } } } }' % temperature
+        ).encode("utf-8")
+        response = self._request(command)
+        self._status["roomTemp"] = temperature
         self._last_status_update = time.monotonic() - 2 * CACHE_INTERVAL_SECONDS
         return response
 


### PR DESCRIPTION
### What Changed

This PR adds support for using any external temperature sensor as the head unit temperature, instead of relying on the return air thermistor which is super unreliable when the unit is off. 